### PR TITLE
Included SubscriptionId in the connection request

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: Azure App Service Publish Profile
-author: Aliencube Community
+name: Azure AppService PublishProfile
+author: Aliencube Community (ediit by McNultyyy)
 description: Retrieve or reset the publish profile of Azure Web App or Functions App in XML format
 
 branding:

--- a/entrypoint.ps1
+++ b/entrypoint.ps1
@@ -15,10 +15,11 @@ Param(
 $clientId = ($env:AZURE_CREDENTIALS | ConvertFrom-Json).clientId
 $clientSecret = ($env:AZURE_CREDENTIALS | ConvertFrom-Json).clientSecret | ConvertTo-SecureString -AsPlainText -Force
 $tenantId = ($env:AZURE_CREDENTIALS | ConvertFrom-Json).tenantId
+$subscriptionId = ($env:AZURE_CREDENTIALS | ConvertFrom-Json).subscriptionId
 
 $credentials = New-Object System.Management.Automation.PSCredential($clientId, $clientSecret)
 
-$connected = Connect-AzAccount -ServicePrincipal -Credential $credentials -Tenant $tenantId
+$connected = Connect-AzAccount -ServicePrincipal -Credential $credentials -Tenant $tenantId -SubscriptionId $subscriptionId
 
 $profile = ""
 


### PR DESCRIPTION
I tried to run the action, but it was failing to find the function app resource as it was not looking in the correct subscription, see below.
![image](https://user-images.githubusercontent.com/9122686/101284142-6d3a5300-37d6-11eb-97d9-a74d28956374.png)

In the case that there are multiple subscriptions, we should explicitly set the SubscriptionId which is stored in the AZURE_CREDENTIALS  json object.