### PR TITLE
Added subscriptionId option for when the configured service principal is assigned access to more than one Azure Subscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This is a GitHub Actions that retrieves or resets the publish profile of Azure W
 * `resourceGroupName` (**Required**): Resource group name.
 * `appName` (**Required**): App instance name.
 * `reset`: Value indicating whether to reset the publish profile or not. If omitted, it's defaulted to `false`.
+* `subscriptionId`: Azure Subscription Id for the App instance. If omitted, it's defaulted to `''`.
 
 
 ## Outputs ##

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: Value indicating whether to reset the publish profile or not.
     required: false
     default: 'false'
+  subscriptionId:
+    description: Optionally provide the Azure Subscription Id to select the appropriate Azure Subscription where the App instance resides.
+    required: false
+    default: ''
 
 outputs:
   profile:
@@ -32,3 +36,5 @@ runs:
   - ${{ inputs.appName }}
   - -Reset
   - ${{ inputs.reset }}
+  - -SubscriptionId
+  - ${{ inputs.subscriptionId }}

--- a/entrypoint.ps1
+++ b/entrypoint.ps1
@@ -9,7 +9,11 @@ Param(
 
     [string]
     [Parameter(Mandatory=$false)]
-    $Reset = "false"
+    $Reset = "false",
+
+    [string]
+    [Parameter(Mandatory=$false)]
+    $SubscriptionId
 )
 
 $clientId = ($env:AZURE_CREDENTIALS | ConvertFrom-Json).clientId
@@ -19,6 +23,10 @@ $tenantId = ($env:AZURE_CREDENTIALS | ConvertFrom-Json).tenantId
 $credentials = New-Object System.Management.Automation.PSCredential($clientId, $clientSecret)
 
 $connected = Connect-AzAccount -ServicePrincipal -Credential $credentials -Tenant $tenantId
+
+if (-not [string]::IsNullOrWhiteSpace($SubscriptionId)) {
+    Set-AzContext -Subscription $SubscriptionId
+}
 
 $profile = ""
 


### PR DESCRIPTION
A previous PR from last year attempted to make a similar change and was closed. This capability will extend the flexibility of this action for use cases when the configured credential loads a default subscription different than the targeted subscription